### PR TITLE
Remove default table override

### DIFF
--- a/src/Database/Models/Tenant.php
+++ b/src/Database/Models/Tenant.php
@@ -28,8 +28,6 @@ class Tenant extends Model implements Contracts\Tenant
         Concerns\TenantRun,
         Concerns\InvalidatesResolverCache;
 
-    protected $table = 'tenants';
-    protected $primaryKey = 'id';
     protected $guarded = [];
 
     public function getTenantKeyName(): string


### PR DESCRIPTION
By setting a default table value, Eloquent cannot automatically detect the table name based on the model name. Unless the developer actively sets a table property. This can cause migration issues when using anything other than a model called`Tenant`. This PR removes the default value and lets eloquent detect the correct table (which, if using the default Tenant model, will default to the current value anyway).

`primaryKey` isn't an issue, but it defaults to eloquents set value anyway, so has also be removed